### PR TITLE
Add constants for mouse buttons 4&5

### DIFF
--- a/libretro.h
+++ b/libretro.h
@@ -208,6 +208,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_MOUSE_MIDDLE           6
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP    7
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN  8
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_4         9
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_5         10
 
 /* Id values for LIGHTGUN types. */
 #define RETRO_DEVICE_ID_LIGHTGUN_X        0


### PR DESCRIPTION
Given the common occurrence of additional buttons on modern mice, I propose adding controls RETRO_DEVICE_ID_MOUSE_BUTTON_4 and RETRO_DEVICE_ID_MOUSE_BUTTON_5 to the set of constants. 

Sega Saturn cores can map these to the missing start input to more accurately represent the real hardware. Other cores, such as for ports of Doom and Quake would also benefit.
